### PR TITLE
Fixed name error

### DIFF
--- a/gpsd/__init__.py
+++ b/gpsd/__init__.py
@@ -195,7 +195,7 @@ class GpsResponse(object):
             raise NoFixError("Needs at least 2D fix")
         return "http://www.openstreetmap.org/?mlat={}&mlon={}&zoom=15".format(self.lat, self.lon)
 
-    def time(self, local_time=False):
+    def get_time(self, local_time=False):
         """ Get the GPS time
 
         :type local_time: bool


### PR DESCRIPTION
Fixed: Because there is a variable self.time and a function time inside
the same class, function time could not be called.

Alternative the name of variable self.time could be changed.