### PR TITLE
Fix bug with time() method name.

### DIFF
--- a/gpsd/__init__.py
+++ b/gpsd/__init__.py
@@ -195,7 +195,7 @@ class GpsResponse(object):
             raise NoFixError("Needs at least 2D fix")
         return "http://www.openstreetmap.org/?mlat={}&mlon={}&zoom=15".format(self.lat, self.lon)
 
-    def time(self, local_time=False):
+    def get_time(self, local_time=False):
         """ Get the GPS time
 
         :type local_time: bool


### PR DESCRIPTION
Attempting to call the time() method on a GpsResponse object fails because GpsResponse objects also have a string member named "time".  Thus, I changed the name of time() to get_time().