### PR TITLE
Handled cases of no satellites seen

### DIFF
--- a/gpsd/__init__.py
+++ b/gpsd/__init__.py
@@ -97,9 +97,14 @@ class GpsResponse(object):
         last_tpv = packet['tpv'][-1]
         last_sky = packet['sky'][-1]
 
-        result.sats = len(last_sky['satellites'])
-        result.sats_valid = len(
-            [sat for sat in last_sky['satellites'] if sat['used'] == True])
+        if 'satellites' in last_sky:
+            result.sats = len(last_sky['satellites'])
+            result.sats_valid = len(
+                [sat for sat in last_sky['satellites'] if sat['used'] == True])
+        else:
+            result.sats = 0;
+            result.sats_valid = 0;
+
         result.mode = last_tpv['mode']
 
         if last_tpv['mode'] >= 2:


### PR DESCRIPTION
I have seen situations where `satellites` field is *absent* in the packet. In such a case, a `KeyError` is raised when `result.sats` and `result.sats_valid` are being set. I have fixed that.