### PR TITLE
Update incorrect command in DOCS.md sample code

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -154,7 +154,7 @@ import gpsd
 gpsd.connect()
 
 # Connect somewhere else
-gpsd.connect()
+gpsd.connect(host="127.0.0.1", port=123456)
 
 # Get gps position
 packet = gpsd.get_current()


### PR DESCRIPTION
- The command for connecting somewhere else was the same as local. This should match the readme to reflect the attributes that can be passed to the connect method for alternative sources.