### PR TITLE
fix bug with get_time returning naive timezone instead of utc

### DIFF
--- a/gpsd/__init__.py
+++ b/gpsd/__init__.py
@@ -221,10 +221,10 @@ class GpsResponse(object):
         """
         if self.mode < 2:
             raise NoFixError("Needs at least 2D fix")
-        time = datetime.datetime.strptime(self.time, gpsTimeFormat)
+        time = datetime.datetime.strptime(self.time, gpsTimeFormat).replace(tzinfo=datetime.timezone.utc)
 
         if local_time:
-            time = time.replace(tzinfo=datetime.timezone.utc).astimezone()
+            time = time.astimezone()
 
         return time
 


### PR DESCRIPTION
assuming `local_time` is False:
`datetime.datetime.strptime(self.time, gpsTimeFormat)` will parse the time format string, which is in UTC, and return a `datetime` object with no timezone info. This naive object will assume that this datetime object was in the local timezone, which is an incorrect assumption--it is in UTC.
Properly adding the `tzinfo` attribute should prevent the `datetime` object from being wrong in the `local_time = False` case.